### PR TITLE
Fix highlighting of references when toggling variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,4 @@ TODO: How to deploy
 
 [travis]: https://travis-ci.org/subugoe/leibniz-frontend
 [travis-badge]: https://travis-ci.org/subugoe/leibniz-frontend.svg?branch=develop
+

--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ TODO: How to deploy
 [travis]: https://travis-ci.org/subugoe/leibniz-frontend
 [travis-badge]: https://travis-ci.org/subugoe/leibniz-frontend.svg?branch=develop
 
+


### PR DESCRIPTION
Remove highlight from associated reference when variant is hidden.

Update loader.js to get rid of deprecation notice, fix test file name.

Resolves: ADWD-2003
